### PR TITLE
Support updating from linux repo github artifacts

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -43,6 +43,7 @@ fi
 BOOT_PATH=${BOOT_PATH:-"/boot"}
 WORK_PATH=${WORK_PATH:-"${ROOT_PATH}/root"}
 SKIP_KERNEL=${SKIP_KERNEL:-0}
+SKIP_FIRMWARE=${SKIP_FIRMWARE:-0}
 SKIP_SDK=${SKIP_SDK:-0}
 SKIP_VCLIBS=${SKIP_VCLIBS:-0}
 SKIP_REPODELETE=${SKIP_REPODELETE:-0}
@@ -340,18 +341,20 @@ function check_partition {
 }
 
 function update_firmware {
-	echo " *** Updating firmware"
-	rm -rf "${FW_PATH}/"start*.elf
-	rm -rf "${FW_PATH}/"fixup*.dat
-	rm -rf "${FW_PATH}/"bootcode.bin
-	if [[ ${WANT_PI4} -eq 1 ]]; then
-		cp "${FW_REPOLOCAL}/"start*.elf "${FW_PATH}/"
-		cp "${FW_REPOLOCAL}/"fixup*.dat "${FW_PATH}/"
-	else
-		cp "${FW_REPOLOCAL}/"start{,[^4]*}.elf "${FW_PATH}/"
-		cp "${FW_REPOLOCAL}/"fixup{,[^4]*}.dat "${FW_PATH}/"
+	if [[ ${SKIP_FIRMWARE} -eq 0 ]]; then
+		echo " *** Updating firmware"
+		rm -rf "${FW_PATH}/"start*.elf
+		rm -rf "${FW_PATH}/"fixup*.dat
+		rm -rf "${FW_PATH}/"bootcode.bin
+		if [[ ${WANT_PI4} -eq 1 ]]; then
+			cp "${FW_REPOLOCAL}/"start*.elf "${FW_PATH}/"
+			cp "${FW_REPOLOCAL}/"fixup*.dat "${FW_PATH}/"
+		else
+			cp "${FW_REPOLOCAL}/"start{,[^4]*}.elf "${FW_PATH}/"
+			cp "${FW_REPOLOCAL}/"fixup{,[^4]*}.dat "${FW_PATH}/"
+		fi
+		cp "${FW_REPOLOCAL}/"*.bin "${FW_PATH}/"
 	fi
-	cp "${FW_REPOLOCAL}/"*.bin "${FW_PATH}/"
 	if [[ ${SKIP_KERNEL} -eq 0 ]]; then
 		if [[ ${WANT_32BIT} -eq 1 ]]; then
 			cp "${FW_REPOLOCAL}/"kernel.img "${FW_REPOLOCAL}/"kernel7.img "${FW_PATH}/"

--- a/rpi-update
+++ b/rpi-update
@@ -357,13 +357,14 @@ function update_firmware {
 	fi
 	if [[ ${SKIP_KERNEL} -eq 0 ]]; then
 		if [[ ${WANT_32BIT} -eq 1 ]]; then
-			cp "${FW_REPOLOCAL}/"kernel.img "${FW_REPOLOCAL}/"kernel7.img "${FW_PATH}/"
+			[[ -e "${FW_REPOLOCAL}/"kernel.img ]] && cp "${FW_REPOLOCAL}/"kernel.img "${FW_PATH}/"
+			[[ -e "${FW_REPOLOCAL}/"kernel7.img ]] && cp "${FW_REPOLOCAL}/"kernel7.img "${FW_PATH}/"
 			if [[ ${WANT_PI4} -eq 1 ]]; then
-				cp "${FW_REPOLOCAL}/"kernel7l.img "${FW_PATH}/"
+				[[ -e "${FW_REPOLOCAL}/"kernel7l.img ]] && cp "${FW_REPOLOCAL}/"kernel7l.img "${FW_PATH}/"
 			fi
 		fi
 		if [[ ${WANT_64BIT} -eq 1 ]]; then
-			cp "${FW_REPOLOCAL}/"kernel8.img "${FW_PATH}/"
+			[[ -e "${FW_REPOLOCAL}/"kernel8.img ]] && cp "${FW_REPOLOCAL}/"kernel8.img "${FW_PATH}/"
 		fi
 		if [[ -n $(shopt -s nullglob; echo "${FW_REPOLOCAL}/"*.dtb*) ]]; then
 			cp "${FW_REPOLOCAL}/"*.dtb* "${FW_PATH}/"

--- a/rpi-update
+++ b/rpi-update
@@ -436,7 +436,7 @@ function do_update {
 	if [ -f ${FW_PATH}/kernel8.img ]; then
 		WANT_64BIT=${WANT_64BIT:-1}
 	fi
-	if [ -f ${FW_PATH}/start4.elf ]; then
+	if [ -f ${FW_PATH}/start4.elf ] || [ -f ${BOOT_PATH}/start4.elf ]; then
 		WANT_PI4=${WANT_PI4:-1}
 	fi
 	WANT_32BIT=${WANT_32BIT:-0}

--- a/rpi-update
+++ b/rpi-update
@@ -58,6 +58,7 @@ JUST_CHECK=${JUST_CHECK:-0}
 RPI_REBOOT=${RPI_REBOOT:-0}
 CURL_OPTIONS=${CURL_OPTIONS:-""}
 GITHUB_API_TOKEN=${GITHUB_API_TOKEN:-""}
+REDIRECTOR=${REDIRECTOR:-"https://builds.raspberrypi.com/github/linux"}
 
 FW_REPO="${REPO_URI}.git"
 FW_REPOLOCAL=${FW_REPOLOCAL:-"${WORK_PATH}/.rpi-firmware"}
@@ -481,7 +482,30 @@ function do_update {
 }
 
 function download_rev {
-	if [[ ${SKIP_DOWNLOAD} -eq 0 ]]; then
+	if [[ "${ARTIFACT}" != "" ]]; then
+		if [[ -f ${FW_REV_IN} ]]; then
+			GET="cat"
+		else
+			GET="curl ${CURL_OPTIONS}"
+		fi
+		echo " *** Downloading specific artifact revision (this will take a few minutes)"
+		rm -rf "${FW_REPOLOCAL}"
+		mkdir -p "${FW_REPOLOCAL}"
+		for build in ${BUILD}; do
+			if [[ ${FW_REV_IN} != http* ]] && [[ ! -f ${FW_REV_IN} ]]; then
+				A="${REDIRECTOR}/${ARTIFACT}/${build}"
+			else
+				A="${ARTIFACT}"
+			fi
+			echo "${GET} ${A} | zcat | tar xf - -C ${FW_REPOLOCAL} --strip-components=2"
+			if ! eval ${GET} "${A}" | zcat | tar xf - -C "${FW_REPOLOCAL}" --strip-components=2; then
+				if [[ ${GET} = curl* ]]; then
+					echo Invalid artifact specified. Response: $( ${GET} "${A}" -o /dev/null -w "%{http_code}" ).
+				fi
+				exit 1
+			fi
+		done
+	elif [[ ${SKIP_DOWNLOAD} -eq 0 ]]; then
 		local FW_TARBALL_URI=${REPO_URI}/tarball/${FW_REV}
 		if ! eval curl -fs ${CURL_OPTIONS} --output /dev/null --head "${FW_TARBALL_URI}"; then
 			echo "Invalid git hash specified"
@@ -606,7 +630,34 @@ if [[ "${FW_REV_IN}" == "" ]]; then
 	FW_REV_IN=${BRANCH}
 fi
 
-FW_REV=$(get_long_hash "${FW_REV_IN}")
+ARTIFACT=""
+BUILD=""
+FW_REV=""
+if [[ ${FW_REV_IN} != http* ]] && [[ ! -f ${FW_REV_IN} ]]; then
+	FW_REV=$(get_long_hash "${FW_REV_IN}")
+fi
+
+echo FW_REV:$FW_REV
+
+if [[ "${FW_REV}" == "" ]]; then
+	if [[ ${FW_REV_IN} != http* ]] && [[ ! -f ${FW_REV_IN} ]]; then
+		IFS=':' read ARTIFACT BUILD <<<${FW_REV_IN}
+		if [[ "${BUILD}" == "" ]]; then
+			BUILD="bcmrpi bcm2709 bcm2711 bcm2711_arm64"
+		fi
+		if [[ "${ARTIFACT}" == pulls/* ]]; then
+			PULL=${ARTIFACT##*/}
+			ARTIFACT=$(eval curl -s "https://api.github.com/repos/raspberrypi/linux/pulls/${PULL}" | awk '/"sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
+		fi
+	else
+		ARTIFACT=${FW_REV_IN}
+		BUILD=dummy
+	fi
+	FW_REV=${ARTIFACT}
+	SKIP_FIRMWARE=1
+	SKIP_SDK=1
+	SKIP_VCLIBS=1
+fi
 
 if [[ "${FW_REV}" == "" ]]; then
 	echo " *** Invalid hash given"
@@ -622,7 +673,11 @@ if [[ ! -f "${FW_REVFILE}" ]]; then
 	fi
 	do_backup
 else
-	LOCAL_HASH=$(get_long_hash "$(cat "${FW_REVFILE}")")
+	if [[ "${ARTIFACT}" != "" ]]; then
+		LOCAL_HASH=$(cat "${FW_REVFILE}")
+	else
+		LOCAL_HASH=$(get_long_hash "$(cat "${FW_REVFILE}")")
+	fi
 	if [[ "${LOCAL_HASH}" == "${FW_REV}" ]]; then
 		echo " *** Your firmware is already up to date (delete ${FW_REVFILE} to force an update anyway)"
 		exit 0


### PR DESCRIPTION
Now that linux kernel PRs automatically build kernel artifacts,
it could be useful for early testing to update directly from the artifact zip file.

The artifacts are found from linux repo, actions, Pi kernel build tests, workflow link.
Then clock number of artifacts (currently 6) and the specific buld you want (e.g. bcm2711_build)

github doesn't provide easy automatic access to artifact links, but they can be downloaded
and the local zip file can be used with:
rpi-upate <zip file>
or you can use a download url (using a different download site, or a github artifact proxy)
rpi-update <http url>
