### PR TITLE
rpi-update: Warn against unsupported command line parameters

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -3,6 +3,14 @@
 set -o nounset
 set -o errexit
 
+for i in $*; do
+  if [[ $i == -* ]]; then
+    echo "rpi-update does not accept command line dash parameters."
+    echo "See: https://github.com/raspberrypi/rpi-update/blob/master/README.md"
+    exit 1
+  fi
+done
+
 REPO_URI=${REPO_URI:-"https://github.com/raspberrypi/rpi-firmware"}
 REPO_API_URI=${REPO_URI/github.com/api.github.com\/repos}
 REPO_CONTENT_URI=${REPO_URI/github.com/raw.githubusercontent.com}


### PR DESCRIPTION
There seem to be users who think passing '-y' or '-v' will do something useful. Explicitly warn against this.