### PR TITLE
rpi-update: Default to /boot/firmware if mountpoint exists

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -48,7 +48,11 @@ if [[ "${FW_SUBDIR}" != "" ]]; then
 		FW_SUBDIR=${FW_SUBDIR: : -1}
 	fi
 fi
-BOOT_PATH=${BOOT_PATH:-"/boot"}
+if mountpoint -q /boot/firmware ; then
+        BOOT_PATH=${BOOT_PATH:-"/boot/firmware"}
+else
+        BOOT_PATH=${BOOT_PATH:-"/boot"}
+fi
 WORK_PATH=${WORK_PATH:-"${ROOT_PATH}/root"}
 SKIP_KERNEL=${SKIP_KERNEL:-0}
 SKIP_FIRMWARE=${SKIP_FIRMWARE:-0}


### PR DESCRIPTION
Future packaging of the linux kernel results in the mountpoint 
of the boot partition moving to /boot/firmware. Lets handle that.