### PR TITLE
rpi-update: Also copy kernel_2712.img

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -399,6 +399,7 @@ function update_firmware {
 		fi
 		if [[ ${WANT_64BIT} -eq 1 ]]; then
 			[[ -e "${FW_REPOLOCAL}/"kernel8.img ]] && cp "${FW_REPOLOCAL}/"kernel8.img "${FW_PATH}/"
+			[[ -e "${FW_REPOLOCAL}/"kernel_2712.img ]] && cp "${FW_REPOLOCAL}/"kernel_2712.img "${FW_PATH}/"
 		fi
 		if [[ -n $(shopt -s nullglob; echo "${FW_REPOLOCAL}/"*.dtb*) ]]; then
 			cp "${FW_REPOLOCAL}/"*.dtb* "${FW_PATH}/"


### PR DESCRIPTION
This is a minimal fix to support 2712 with rpi-update.

After running I get:
```
pi@pi5:~ $ uname -a
Linux pi5 6.1.54-v8_16k+ #1685 SMP PREEMPT Fri Sep 29 11:06:10 BST 2023 aarch64 GNU/Linux
```

I'm hoping existing (non-bookwork) boot partitions can copy with an extra kernel.