### PR TITLE
rpi-update: Extract git hash from artifact build from branch

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -682,6 +682,8 @@ if [[ "${FW_REV}" == "" ]]; then
 		if [[ "${ARTIFACT}" == pulls/* ]]; then
 			PULL=${ARTIFACT##*/}
 			ARTIFACT=$(eval curl -s "https://api.github.com/repos/raspberrypi/linux/pulls/${PULL}" | awk '/"sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
+        else
+			ARTIFACT=$(eval curl -s "https://api.github.com/repos/raspberrypi/linux/actions/artifacts" | grep -A1 "\"head_branch\": \"${FW_REV_IN}\"" | awk '/"head_sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
 		fi
 	else
 		ARTIFACT=${FW_REV_IN}

--- a/rpi-update
+++ b/rpi-update
@@ -677,7 +677,7 @@ if [[ "${FW_REV}" == "" ]]; then
 	if [[ ${FW_REV_IN} != http* ]] && [[ ! -f ${FW_REV_IN} ]]; then
 		IFS=':' read ARTIFACT BUILD <<<${FW_REV_IN}
 		if [[ "${BUILD}" == "" ]]; then
-			BUILD="bcmrpi bcm2709 bcm2711 bcm2711_arm64"
+			BUILD="bcmrpi bcm2709 bcm2711 bcm2711_arm64 bcm2712"
 		fi
 		if [[ "${ARTIFACT}" == pulls/* ]]; then
 			PULL=${ARTIFACT##*/}


### PR DESCRIPTION
This allows rpi-update rpi-6.6.y to correctly skip if no changes or run if there are changes.

Also include bcm2712 in build artifacts downloaded