### PR TITLE
rpi-update: Retrieve 100 artifact results from Github.

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -698,7 +698,7 @@ if [[ "${FW_REV}" == "" ]]; then
 			PULL=${ARTIFACT##*/}
 			ARTIFACT=$(eval curl -s "https://api.github.com/repos/raspberrypi/linux/pulls/${PULL}" | awk '/"sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
         else
-			ARTIFACT=$(eval curl -s "https://api.github.com/repos/raspberrypi/linux/actions/artifacts" | grep -A1 "\"head_branch\": \"${FW_REV_IN}\"" | awk '/"head_sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
+			ARTIFACT=$(eval curl -s "https://api.github.com/repos/raspberrypi/linux/actions/artifacts?per_page=100" | grep -A1 "\"head_branch\": \"${FW_REV_IN}\"" | awk '/"head_sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
 		fi
 	else
 		ARTIFACT=${FW_REV_IN}


### PR DESCRIPTION
Github pages the artifact results, by default only giving the latest 30, but can be increased to 100 per page. If your build has fallen off that list, then tough luck.

Ideally we want to iterate through the pages as well by adding &page=N, but that can come later.

https://github.com/raspberrypi/rpi-update/issues/21