### PR TITLE
rpi-update: Skip updates to /opt if not in repo

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -223,18 +223,24 @@ function update_vc_libs {
 	fi
 	if [[ "${ELFOUTPUT}" != "${ELFOUTPUT/VFP_args/}" || \
 			"${ELFOUTPUT}" != "${ELFOUTPUT/hard-float/}" ]]; then
-		echo " *** Using HardFP libraries"
-		cp -R "${FW_REPOLOCAL}/vc/hardfp/"* "${ROOT_PATH}/"
+		if [ -d "${FW_REPOLOCAL}/vc/hardfp/" ]; then
+			echo " *** Using HardFP libraries"
+			cp -R "${FW_REPOLOCAL}/vc/hardfp/"* "${ROOT_PATH}/"
+		fi
 	else
-		echo " *** Using SoftFP libraries"
-		cp -R "${FW_REPOLOCAL}/vc/softfp/"* "${ROOT_PATH}/"
+		if [ -d "${FW_REPOLOCAL}/vc/softfp/" ]; then
+			echo " *** Using SoftFP libraries"
+			cp -R "${FW_REPOLOCAL}/vc/softfp/"* "${ROOT_PATH}/"
+		fi
 	fi
 }
 
 function update_sdk {
 	if [[ ${SKIP_SDK} -eq 0 ]]; then
-		echo " *** Updating SDK"
-		cp -R "${FW_REPOLOCAL}/vc/sdk/"* "${ROOT_PATH}/"
+		if [ -d "${FW_REPOLOCAL}/vc/sdk/" ]; then
+			echo " *** Updating SDK"
+			cp -R "${FW_REPOLOCAL}/vc/sdk/"* "${ROOT_PATH}/"
+		fi
 	else
 		echo " *** As requested, not updating SDK"
 	fi


### PR DESCRIPTION
The /opt tree is a build of the userland repo which is deprecated, and is no longer provided by firmware/rpi-firmware repos.

Handle skipping these if they are missing.