### PR TITLE
rpi-update: Remove deprecated BRANCH variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,15 +152,6 @@ By default, FW_SUBDIR is initialised to the value of `os_prefix` in effect when
 the device was booted, so as to overwrite the "running" firmware. To explicitly
 install with no subdirectory (to install into /boot), use `FW_SUBDIR=/`.
 
-#### `BRANCH`
-
-By default, clones the firmware files from the master branch, else uses the files
-from the specified branch, eg:
-
-    sudo BRANCH=next rpi-update
-
-will use the 'next' branch.
-
 #### `PRUNE_MODULES`
 
 Allows you to delete unused module directories when doing an update. Set it equal to a non-zero value and it will remove all modules except the latest installed:

--- a/rpi-update
+++ b/rpi-update
@@ -36,7 +36,6 @@ else
 	NOOBS_CHECK=${NOOBS_CHECK:-0}
 fi
 
-BRANCH=${BRANCH:-"master"}
 ROOT_PATH=${ROOT_PATH:-"/"}
 if command -v vcgencmd > /dev/null; then
 	CUR_FW_SUBDIR="/$(echo =$(vcgencmd get_config os_prefix) | cut -d'=' -f3)"
@@ -710,6 +709,11 @@ else
 	rm -f "${SELFUPDATE_SCRIPT}"
 fi
 
+if [ "${BRANCH:-"unset"}" != "unset" ]; then
+  echo 'Using the BRANCH variable is deprecated. Just use "rpi-update <branch>"'.
+  exit
+fi
+
 if [[ ! -d "${FW_PATH}" ]]; then
 	echo " !!! ${FW_PATH} doesn't exist - creating"
 	mkdir -p "${FW_PATH}"
@@ -730,14 +734,6 @@ command -v readelf >/dev/null 2>&1 || {
 	echo "     In Arch, try: pacman -S binutils"
 	exit 1
 }
-
-if [[ "${FW_REV_IN}" == "" ]]; then
-	FW_REV_IN=${BRANCH}
-fi
-
-if [[ "${BOOTLOADER_REV_IN}" == "" ]]; then
-	BOOTLOADER_REV_IN=${BRANCH}
-fi
 
 ARTIFACT=""
 BUILD=""


### PR DESCRIPTION
BRANCH currently applies to both firmware and bootloader but typically they won't have branches of the same name (e.g there is no stable branch of bootloader).

So remove the option and encourage using parameters for the two branches