### PR TITLE
URI updates

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -11,9 +11,11 @@ for i in $*; do
   fi
 done
 
+# REPO_URI variable is here for backwards-compatibility
 REPO_URI=${REPO_URI:-"https://github.com/raspberrypi/rpi-firmware"}
-REPO_API_URI=${REPO_URI/github.com/api.github.com\/repos}
-REPO_CONTENT_URI=${REPO_URI/github.com/raw.githubusercontent.com}
+FIRMWARE_REPO_URI=${FIRMWARE_REPO_URI:-$REPO_URI}
+FIRMWARE_REPO_API_URI=${FIRMWARE_REPO_URI/github.com/api.github.com\/repos}
+FIRMWARE_REPO_CONTENT_URI=${FIRMWARE_REPO_URI/github.com/raw.githubusercontent.com}
 
 BOOTLOADER_REPO_URI=${BOOTLOADER_REPO_URI:-"https://github.com/raspberrypi/rpi-eeprom"}
 BOOTLOADER_REPO_API_URI=${BOOTLOADER_REPO_URI/github.com/api.github.com\/repos}
@@ -344,7 +346,7 @@ function update_bootloader {
 }
 
 function show_notice {
-	local NOTICE_URI=${REPO_CONTENT_URI}/${FW_REV}/NOTICE.md
+	local NOTICE_URI=${FIRMWARE_REPO_CONTENT_URI}/${FW_REV}/NOTICE.md
 	local FULL_NOTICE=$(eval curl -fs ${CURL_OPTIONS} "${NOTICE_URI}")
 	if [ -z "${FULL_NOTICE}" ]; then
 		return
@@ -359,8 +361,8 @@ function show_notice {
 	if ${NOTICE_HASH_EXISTS}; then
 		local NOTICE=$(echo "${FULL_NOTICE}" | tail -n+2)
 		local NEW_HASH=${FW_REV}
-		local LOCAL_lt_NOTICE=$(compare_hashes "${REPO_API_URI}" "${LOCAL_HASH}" lt "${NOTICE_HASH}")
-		local NEW_ge_NOTICE=$(compare_hashes "${REPO_API_URI}" "${NEW_HASH}" ge "${NOTICE_HASH}")
+		local LOCAL_lt_NOTICE=$(compare_hashes "${FIRMWARE_REPO_API_URI}" "${LOCAL_HASH}" lt "${NOTICE_HASH}")
+		local NEW_ge_NOTICE=$(compare_hashes "${FIRMWARE_REPO_API_URI}" "${NEW_HASH}" ge "${NOTICE_HASH}")
 		if ! ${LOCAL_lt_NOTICE} && ! ${NEW_ge_NOTICE}; then
 			return
 		fi
@@ -609,7 +611,7 @@ function download_rev {
 			fi
 		done
 	elif [[ ${SKIP_DOWNLOAD} -eq 0 ]]; then
-		local FW_TARBALL_URI=${REPO_URI}/tarball/${FW_REV}
+		local FW_TARBALL_URI=${FIRMWARE_REPO_URI}/tarball/${FW_REV}
 		if ! eval curl -fs ${CURL_OPTIONS} --output /dev/null --head "${FW_TARBALL_URI}"; then
 			echo "Invalid git hash specified"
 			exit 1
@@ -747,7 +749,7 @@ ARTIFACT=""
 BUILD=""
 FW_REV=""
 if [[ ${FW_REV_IN} != http* ]] && [[ ! -f ${FW_REV_IN} ]]; then
-	FW_REV=$(get_long_hash "${REPO_API_URI}" "${FW_REV_IN}")
+	FW_REV=$(get_long_hash "${FIRMWARE_REPO_API_URI}" "${FW_REV_IN}")
 fi
 
 echo FW_REV:$FW_REV
@@ -812,7 +814,7 @@ else
 			BOOTLOADER_LOCAL_HASH=$(cat "${BOOTLOADER_REVFILE}")
 		fi
 	else
-		LOCAL_HASH=$(get_long_hash ${REPO_API_URI} "$(cat "${FW_REVFILE}")")
+		LOCAL_HASH=$(get_long_hash ${FIRMWARE_REPO_API_URI} "$(cat "${FW_REVFILE}")")
 		if [[ "${SKIP_BOOTLOADER}" -eq 0 ]]; then
 			if [[ ! -f "${BOOTLOADER_REVFILE}" ]]; then
 				BOOTLOADER_LOCAL_HASH=0
@@ -840,13 +842,13 @@ else
 	fi
 
 	if [[ ${JUST_CHECK} -ne 0 ]]; then
-		if $(compare_hashes "${REPO_API_URI}" "${LOCAL_HASH}" lt "${FW_REV}"); then
+		if $(compare_hashes "${FIRMWARE_REPO_API_URI}" "${LOCAL_HASH}" lt "${FW_REV}"); then
 			echo " *** Firmware update required. New commits available:"
-			DIFF_URI=${REPO_API_URI}/compare/${LOCAL_HASH}...${FW_REV}
+			DIFF_URI=${FIRMWARE_REPO_API_URI}/compare/${LOCAL_HASH}...${FW_REV}
 			print_diffs "${DIFF_URI}"
-		elif $(compare_hashes "${REPO_API_URI}" "${LOCAL_HASH}" gt "${FW_REV}"); then
+		elif $(compare_hashes "${FIRMWARE_REPO_API_URI}" "${LOCAL_HASH}" gt "${FW_REV}"); then
 			echo " *** Firmware downgrade requested. Commits to drop:"
-			DIFF_URI=${REPO_API_URI}/compare/${FW_REV}...${LOCAL_HASH}
+			DIFF_URI=${FIRMWARE_REPO_API_URI}/compare/${FW_REV}...${LOCAL_HASH}
 			print_diffs "${DIFF_URI}"
 		fi
 

--- a/rpi-update
+++ b/rpi-update
@@ -74,7 +74,9 @@ JUST_CHECK=${JUST_CHECK:-0}
 RPI_REBOOT=${RPI_REBOOT:-0}
 CURL_OPTIONS=${CURL_OPTIONS:-""}
 GITHUB_API_TOKEN=${GITHUB_API_TOKEN:-""}
+# REDIRECTOR variable is here for backwards-compatibility
 REDIRECTOR=${REDIRECTOR:-"https://builds.raspberrypi.com/github/linux"}
+REDIRECTOR_URI=${REDIRECTOR_URI:-$REDIRECTOR}
 
 FW_REPO="${REPO_URI}.git"
 FW_REPOLOCAL=${FW_REPOLOCAL:-"${WORK_PATH}/.rpi-firmware"}
@@ -591,7 +593,7 @@ function download_rev {
 		mkdir -p "${FW_REPOLOCAL}"
 		for build in ${BUILD}; do
 			if [[ ${FW_REV_IN} != http* ]] && [[ ! -f ${FW_REV_IN} ]]; then
-				A="${REDIRECTOR}/${ARTIFACT}/${build}"
+				A="${REDIRECTOR_URI}/${ARTIFACT}/${build}"
 			else
 				A="${ARTIFACT}"
 			fi

--- a/rpi-update
+++ b/rpi-update
@@ -23,7 +23,7 @@ LINUX_REPO_URI=${LINUX_REPO_URI:-"https://github.com/raspberrypi/linux"}
 LINUX_REPO_API_URI=${LINUX_REPO_URI/github.com/api.github.com\/repos}
 
 UPDATE_SELF=${UPDATE_SELF:-1}
-UPDATE_REPO_URI="https://github.com/raspberrypi/rpi-update"
+UPDATE_REPO_URI=${UPDATE_REPO_URI:-"https://github.com/raspberrypi/rpi-update"}
 UPDATE_REPO_CONTENT_URI=${UPDATE_REPO_URI/github.com/raw.githubusercontent.com}
 UPDATE_URI="${UPDATE_REPO_CONTENT_URI}/master/rpi-update"
 

--- a/rpi-update
+++ b/rpi-update
@@ -116,7 +116,7 @@ CURL_OPTIONS_API="${CURL_OPTIONS_API:-"-A curl"}"
 # Support for custom GitHub Auth Tokens
 if [[ -n "${GITHUB_API_TOKEN}" ]]; then
 	echo " *** Using GitHub token for all requests."
-	CURL_OPTIONS="${CURL_OPTIONS} --header \"Authorization: token ${GITHUB_API_TOKEN}\""
+	CURL_OPTIONS_API="${CURL_OPTIONS_API} --header \"Authorization: token ${GITHUB_API_TOKEN}\""
 fi
 
 GITHUB_API_LIMITED=$(eval curl ${CURL_OPTIONS_API} -s ${CURL_OPTIONS} "https://api.github.com/rate_limit" | tr -d "," | awk 'BEGIN {reset=0;} { if ($1 == "\"limit\":") limit=$2; else if ($1 == "\"remaining\":") remaining=$2; else if ($1 == "\"reset\":" && limit>0 && remaining==0) reset=$2;} END { print reset }')
@@ -267,7 +267,7 @@ function download_bootloader_tools {
 
 function download_bootloader_images {
 	bcm_chip=$1
-	latest_eeprom=$(eval curl -fs ${CURL_OPTIONS} ${BOOTLOADER_REPO_API_URI}/git/trees/${BOOTLOADER_REV}?recursive=1 | grep "firmware-${bcm_chip}/latest/pieeprom" | sed 's/.*\(pieeprom.*\)".*/\1/' | sort -r | head -n1)
+	latest_eeprom=$(eval curl ${CURL_OPTIONS_API} -fs ${CURL_OPTIONS} ${BOOTLOADER_REPO_API_URI}/git/trees/${BOOTLOADER_REV}?recursive=1 | grep "firmware-${bcm_chip}/latest/pieeprom" | sed 's/.*\(pieeprom.*\)".*/\1/' | sort -r | head -n1)
 	if [[ -n "${latest_eeprom}" ]]; then
 		fw_path="/lib/firmware/raspberrypi/bootloader-${bcm_chip}/latest"
 		if [[ ! -d "${fw_path}" ]]; then
@@ -771,9 +771,9 @@ if [[ "${FW_REV}" == "" ]]; then
 		fi
 		if [[ "${ARTIFACT}" == pulls/* ]]; then
 			PULL=${ARTIFACT##*/}
-			ARTIFACT=$(eval curl -s "${LINUX_REPO_API_URI}/pulls/${PULL}" | awk '/"sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
+			ARTIFACT=$(eval curl ${CURL_OPTIONS_API} -s "${LINUX_REPO_API_URI}/pulls/${PULL}" | awk '/"sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
         else
-			ARTIFACT=$(eval curl -s "${LINUX_REPO_API_URI}/actions/artifacts?per_page=100" | grep -A1 "\"head_branch\": \"${FW_REV_IN}\"" | awk '/"head_sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
+			ARTIFACT=$(eval curl ${CURL_OPTIONS_API} -s "${LINUX_REPO_API_URI}/actions/artifacts?per_page=100" | grep -A1 "\"head_branch\": \"${FW_REV_IN}\"" | awk '/"head_sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
 		fi
 	else
 		ARTIFACT=${FW_REV_IN}

--- a/rpi-update
+++ b/rpi-update
@@ -19,6 +19,9 @@ BOOTLOADER_REPO_URI=${BOOTLOADER_REPO_URI:-"https://github.com/raspberrypi/rpi-e
 BOOTLOADER_REPO_API_URI=${BOOTLOADER_REPO_URI/github.com/api.github.com\/repos}
 BOOTLOADER_REPO_CONTENT_URI=${BOOTLOADER_REPO_URI/github.com/raw.githubusercontent.com}
 
+LINUX_REPO_URI=${LINUX_REPO_URI:-"https://github.com/raspberrypi/linux"}
+LINUX_REPO_API_URI=${LINUX_REPO_URI/github.com/api.github.com\/repos}
+
 UPDATE_SELF=${UPDATE_SELF:-1}
 UPDATE_REPO_URI="https://github.com/raspberrypi/rpi-update"
 UPDATE_REPO_CONTENT_URI=${UPDATE_REPO_URI/github.com/raw.githubusercontent.com}
@@ -766,9 +769,9 @@ if [[ "${FW_REV}" == "" ]]; then
 		fi
 		if [[ "${ARTIFACT}" == pulls/* ]]; then
 			PULL=${ARTIFACT##*/}
-			ARTIFACT=$(eval curl -s "https://api.github.com/repos/raspberrypi/linux/pulls/${PULL}" | awk '/"sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
+			ARTIFACT=$(eval curl -s "${LINUX_REPO_API_URI}/pulls/${PULL}" | awk '/"sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
         else
-			ARTIFACT=$(eval curl -s "https://api.github.com/repos/raspberrypi/linux/actions/artifacts?per_page=100" | grep -A1 "\"head_branch\": \"${FW_REV_IN}\"" | awk '/"head_sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
+			ARTIFACT=$(eval curl -s "${LINUX_REPO_API_URI}/actions/artifacts?per_page=100" | grep -A1 "\"head_branch\": \"${FW_REV_IN}\"" | awk '/"head_sha":/ {gsub(/"/, "", $2); gsub(/,/, "", $2); print $2; exit}')
 		fi
 	else
 		ARTIFACT=${FW_REV_IN}

--- a/rpi-update
+++ b/rpi-update
@@ -671,8 +671,8 @@ function noobs_fix {
 }
 
 function get_hash_date {
-	local COMMITS_URI=${1}/commits/$2
-	eval curl ${CURL_OPTIONS_API} -s ${CURL_OPTIONS} "${COMMITS_URI}" | grep "date" | head -1 | awk -F\" '{print $4}'
+	local COMMITS_API_URI=${1}/commits/$2
+	eval curl ${CURL_OPTIONS_API} -s ${CURL_OPTIONS} "${COMMITS_API_URI}" | grep "date" | head -1 | awk -F\" '{print $4}'
 }
 
 function compare_hashes {
@@ -687,14 +687,14 @@ function compare_hashes {
 
 function get_long_hash {
 	# ask github for long version hash
-	local COMMITS_URI=${1}/commits/$2
-	eval curl ${CURL_OPTIONS_API} -s ${CURL_OPTIONS} "${COMMITS_URI}" | awk 'BEGIN {hash=""} { if (hash == "" && $1 == "\"sha\":") {hash=substr($2, 2, 40);} } END {print hash}'
+	local COMMITS_API_URI=${1}/commits/$2
+	eval curl ${CURL_OPTIONS_API} -s ${CURL_OPTIONS} "${COMMITS_API_URI}" | awk 'BEGIN {hash=""} { if (hash == "" && $1 == "\"sha\":") {hash=substr($2, 2, 40);} } END {print hash}'
 }
 
 function print_diffs {
-	local diff_uri="$1"
+	local DIFF_API_URI="$1"
 	SEPARATOR="======================================================"
-	eval curl ${CURL_OPTIONS_API} -s ${CURL_OPTIONS} "${diff_uri}" | awk -v SEPARATOR="${SEPARATOR}" -F\" ' { if ($2 == "commits") {commits=1} if (commits && $2 == "message") {print SEPARATOR "\nCommit: " $4} }' | sed 's/\\n\\n/\nCommit:\ /g'
+	eval curl ${CURL_OPTIONS_API} -s ${CURL_OPTIONS} "${DIFF_API_URI}" | awk -v SEPARATOR="${SEPARATOR}" -F\" ' { if ($2 == "commits") {commits=1} if (commits && $2 == "message") {print SEPARATOR "\nCommit: " $4} }' | sed 's/\\n\\n/\nCommit:\ /g'
 }
 
 


### PR DESCRIPTION
Lots of "little tidyups" (which I've separated into separate commits for clarity), but the main thing this fixes is that the GitHub API token wasn't being passed to **all** GitHub API requests, which meant that if GitHub was being rate-limited, then running any of the commands listed at https://github.com/raspberrypi/rpi-update?tab=readme-ov-file#using-github-artifacts-from-automated-builds would just fail with a cryptic "Invalid git hash specified" error. I bet you'll never guess how I discovered this error... :laughing: 