### PR TITLE
Skip invalid hash when using custom FW_REPOLOCAL

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -785,7 +785,7 @@ if [[ "${FW_REV}" == "" ]]; then
 	SKIP_VCLIBS=1
 fi
 
-if [[ "${FW_REV}" == "" ]]; then
+if [[ "${FW_REV}" == "" ]] && [[ "$FW_REPOLOCAL" == "${WORK_PATH}/.rpi-firmware" ]]; then
 	echo " *** Invalid hash given"
 	exit 1
 fi


### PR DESCRIPTION
There is a mode where you can run rpi-update without a network, if you have a local copy of the repo files. e.g.

SKIP_DOWNLOAD=1 SKIP_REPODELETE=1 FW_REPOLOCAL=/home/dom/.rpi-firmware rpi-update

That is currently not usable because of the git hash check. So fix it.