### PR TITLE
Remove bcm2711_64 as a build

### DIFF
--- a/rpi-update
+++ b/rpi-update
@@ -779,7 +779,7 @@ if [[ "${FW_REV}" == "" ]]; then
 	if [[ ${FW_REV_IN} != http* ]] && [[ ! -f ${FW_REV_IN} ]]; then
 		IFS=':' read ARTIFACT BUILD <<<${FW_REV_IN}
 		if [[ "${BUILD}" == "" ]]; then
-			BUILD="bcmrpi bcm2709 bcm2711 bcm2711_arm64 bcm2711_rt bcm2712"
+			BUILD="bcmrpi bcm2709 bcm2711 bcm2711_rt bcm2712"
 		fi
 		if [[ "${ARTIFACT}" == pulls/* ]]; then
 			PULL=${ARTIFACT##*/}


### PR DESCRIPTION
With the dropping of the 32-bit bcm2711 (v7l) kernel, the generic 64-bit build is now renamed to bcm2711 and the bcm2711_64 disappears; don't try to download it.

See: https://github.com/raspberrypi/rpi-update/issues/47